### PR TITLE
Convert preview page to mjpeg

### DIFF
--- a/www/cgi-bin/image.cgi
+++ b/www/cgi-bin/image.cgi
@@ -1,13 +1,18 @@
 #!/bin/sh
 preview=/tmp/snapshot.jpg
-date=$(TZ=GMT0 date +'%a, %d %b %Y %T %Z')
 echo "HTTP/1.1 200 OK
-Content-type: image/jpeg
-Content-Disposition: inline; filename=preview-$(date +%s).jpg
-Cache-Control: no-store
+Content-Type: multipart/x-mixed-replace; boundary=frame
 Pragma: no-cache
-Date: $date
-Expires: $date
 Connecton: close
 "
+
+echo -n -e "--frame\r\nContent-Type: image/jpeg\r\n\r\n"
 cat $preview
+echo -n -e "--frame\r\nContent-Type: image/jpeg\r\n\r\n"
+while [ 1 ]
+do
+    cat $preview
+    echo -n -e "\r\n\r\n"
+    echo -n -e "--frame\r\nContent-Type: image/jpeg\r\n\r\n"
+    sleep 1
+done

--- a/www/cgi-bin/image.cgi
+++ b/www/cgi-bin/image.cgi
@@ -1,18 +1,18 @@
 #!/bin/sh
 preview=/tmp/snapshot.jpg
+frame="--frame\r\nContent-Type: image/jpeg\r\n\r\n"
 echo "HTTP/1.1 200 OK
 Content-Type: multipart/x-mixed-replace; boundary=frame
 Pragma: no-cache
 Connecton: close
 "
 
-echo -n -e "--frame\r\nContent-Type: image/jpeg\r\n\r\n"
+echo -n -e $frame
 cat $preview
-echo -n -e "--frame\r\nContent-Type: image/jpeg\r\n\r\n"
-while [ 1 ]
-do
+echo -n -e $frame
+while :; do
     cat $preview
     echo -n -e "\r\n\r\n"
-    echo -n -e "--frame\r\nContent-Type: image/jpeg\r\n\r\n"
+    echo -n -e $frame
     sleep 1
 done

--- a/www/cgi-bin/preview.cgi
+++ b/www/cgi-bin/preview.cgi
@@ -1,23 +1,3 @@
-#!/bin/sh
-preview=/tmp/snapshot.jpg
-echo "HTTP/1.1 200 OK
-Content-Type: multipart/x-mixed-replace; boundary=frame
-Pragma: no-cache
-Connecton: close
-"
-
-echo -n -e "--frame\r\nContent-Type: image/jpeg\r\n\r\n"
-cat $preview
-echo -n -e "--frame\r\nContent-Type: image/jpeg\r\n\r\n"
-sleep 5
-while [ 1 ]
-do
-cat $preview
-echo -n -e "\r\n\r\n"
-echo -n -e "--frame\r\nContent-Type: image/jpeg\r\n\r\n"
-sleep 1
-done
-[root@thingino-t31l cgi-bin]# cat preview.cgi
 #!/usr/bin/haserl
 <%in p/common.cgi %>
 <%in p/icons.cgi %>

--- a/www/cgi-bin/preview.cgi
+++ b/www/cgi-bin/preview.cgi
@@ -31,7 +31,7 @@ check_mirror() {
 <div class="bar2"></div>
 <div class="bar3"></div>
 </div>
-<img id="preview" ></img>
+<img id="preview"></img>
 <%in p/motors.cgi %>
 
 <div id="controls" class="position-absolute bottom-0 start-0 end-0">
@@ -143,10 +143,10 @@ async function loaded() {
 	while (true) {
 		await jpg.decode().catch(function() {
 			console.log("restarting mjpeg");
-			jpg.src="";
-			jpg.src=pimg;
+			jpg.src = "";
+			jpg.src = pimg;
 		});
-	await new Promise((resolve) => setTimeout(resolve, 5000));
+		await new Promise((resolve) => setTimeout(resolve, 5000));
 	}
 }
 
@@ -161,7 +161,7 @@ function calculatePreviewSize() {
 		ph -= ph % 16
 
 		console.log(pw, ph);
-		const frame= $('#frame');
+		const frame = $('#frame');
 		frame.style.width = pw + 'px';
 		frame.style.height = ph + 'px';
 


### PR DESCRIPTION
This change updates the preview page to use an MJPEG stream instead of a constantly refreshing image URL. This simplifies many things, including cache issues and network failures, as well as moving from 1 http request per second to 1 http request that persists while the stream is open.